### PR TITLE
Merge crop-specific and cultivar-specific params into a single structure

### DIFF
--- a/src/agsys/ctsm_interface/AgSysInterface.F90
+++ b/src/agsys/ctsm_interface/AgSysInterface.F90
@@ -17,7 +17,7 @@ module AgSysInterface
   use TemperatureType, only : temperature_type
   use AgSysConstants, only : crop_type_maxval, crop_type_not_handled
   use AgSysType, only : agsys_type
-  use AgSysParams, only : agsys_crop_params_type, agsys_crop_cultivar_params_type
+  use AgSysParams, only : agsys_crop_cultivar_params_type
   use AgSysPhases, only : agsys_phases_type
   use AgSysParamReader, only : ReadParams, ReadPhases
   use AgSysRuntimeConstants, only : InitRuntimeConstants
@@ -30,9 +30,6 @@ module AgSysInterface
 
   type, public :: agsys_interface_type
      private
-     ! Parameters that vary by crop type
-     type(agsys_crop_params_type) :: crop_params(crop_type_maxval)
-
      ! Parameters that vary by cultivar; these are first indexed by crop type, then
      ! indexed by the specific cultivar for that crop. For example:
      !
@@ -40,7 +37,6 @@ module AgSysInterface
      !    crop_type = agsys_general_inst%crop_type_patch(p)
      !    cultivar  = agsys_general_inst%cultivar_patch(p)
      !    call SomeAgsysRoutine( &
-     !         crop_params     = agsys_inst%crop_params(crop_type), &
      !         cultivar_params = agsys_inst%crop_cultivar_params(crop_type)%cultivar_params(cultivar), &
      !         ...)
      ! end do
@@ -128,7 +124,6 @@ contains
                   ! Inputs, time-constant
                   croptype        = crop_type, &
                   phases          = this%crop_phases(crop_type), &
-                  crop_params     = this%crop_params(crop_type), &
                   cultivar_params = this%crop_cultivar_params(crop_type)%cultivar_params(cultivar), &
 
                   ! Inputs, time-varying
@@ -172,7 +167,7 @@ contains
     character(len=*), parameter :: subname = 'Init'
     !-----------------------------------------------------------------------
 
-    call ReadParams(this%crop_params, this%crop_cultivar_params)
+    call ReadParams(this%crop_cultivar_params)
     call ReadPhases(this%crop_phases)
     call InitRuntimeConstants(this%crop_phases)
     call this%agsys_inst%Init(bounds)

--- a/src/agsys/ctsm_interface/AgSysParamReader.F90
+++ b/src/agsys/ctsm_interface/AgSysParamReader.F90
@@ -8,7 +8,7 @@ module AgSysParamReader
 #include "shr_assert.h"
   use shr_kind_mod     , only : r8 => shr_kind_r8
   use shr_infnan_mod   , only : nan => shr_infnan_nan, assignment(=)
-  use AgSysParams      , only : agsys_crop_params_type, agsys_crop_cultivar_params_type
+  use AgSysParams      , only : agsys_crop_cultivar_params_type
   use AgSysPhases      , only : agsys_phases_type
   use AgSysConstants   , only : crop_type_maxval, crop_type_maize
   !
@@ -25,13 +25,12 @@ module AgSysParamReader
 contains
 
   !-----------------------------------------------------------------------
-  subroutine ReadParams(crop_params, crop_cultivar_params)
+  subroutine ReadParams(crop_cultivar_params)
     !
     ! !DESCRIPTION:
     ! Read parameters
     !
     ! !ARGUMENTS:
-    type(agsys_crop_params_type), intent(inout) :: crop_params(:)
     type(agsys_crop_cultivar_params_type), intent(inout) :: crop_cultivar_params(:)
     !
     ! !LOCAL VARIABLES:
@@ -39,10 +38,7 @@ contains
     character(len=*), parameter :: subname = 'ReadParams'
     !-----------------------------------------------------------------------
 
-    SHR_ASSERT_FL((size(crop_params) == crop_type_maxval), sourcefile, __LINE__)
     SHR_ASSERT_FL((size(crop_cultivar_params) == crop_type_maxval), sourcefile, __LINE__)
-
-    crop_params(crop_type_maize)%shoot_lag = 0  ! TODO(wjs, 2019-11-08) fix this
 
     allocate(crop_cultivar_params(crop_type_maize)%cultivar_params(1))
 

--- a/src/agsys/science/AgSysParams.F90
+++ b/src/agsys/science/AgSysParams.F90
@@ -5,9 +5,6 @@ module AgSysParams
   ! Derived type holding AgSys's time-constant parameters, defining various crops and
   ! cultivars
   !
-  ! Variables with suffix '_crop' are indexed by crop_type; variables with suffix
-  ! '_cultivar' are indexed by cultivar.
-  !
   ! !USES:
   use AgSysKinds, only : r8
   !
@@ -25,14 +22,22 @@ module AgSysParams
      real(r8), allocatable, public :: y(:)
   end type response_curve_type
 
-  ! Parameters that vary by crop
-  type, public :: agsys_crop_params_type
+  ! Parameters that vary by cultivar. Some of these may be the same for all cultivars of a
+  ! crop, but this structure allows flexibility in terms of which parameters are
+  ! crop-specific and which are cultivar-specific.
+  !
+  ! TODO(wjs, 2019-11-11) We may want to have a base type that includes parameters that
+  ! apply to all crops, and then children types for specific crops that hold parameters
+  ! specific to that crop.
+  type, public :: agsys_cultivar_params_type
      private
 
      ! Public data members
      integer, allocatable,      public :: MaxDaysFromSowingToEndofPhase(:)
      real(r8),                  public :: shoot_lag
      real(r8),                  public :: shoot_rate
+     real(r8), allocatable,     public :: phase_TargetTT(:)  !!target thermal time to finish a phase
+     type(response_curve_type), public :: target_tt_from_photoperiod_end_of_juvenile
      type(response_curve_type), public :: response_curve_tt
      type(response_curve_type), public :: response_curve_vd
      type(response_curve_type), public :: rc_sw_avail_phenol
@@ -42,15 +47,6 @@ module AgSysParams
      real(r8),                  public :: p_photop_sens
      real(r8),                  public :: p_vern_sens
      real(r8),                  public :: p_pesw_germ
-  end type agsys_crop_params_type
-
-  ! Parameters that vary by cultivar
-  type, public :: agsys_cultivar_params_type
-     private
-
-     ! Public data members
-     real(r8), allocatable,     public :: phase_TargetTT(:)  !!target thermal time to finish a phase
-     type(response_curve_type), public :: target_tt_from_photoperiod_end_of_juvenile
   end type agsys_cultivar_params_type
 
   ! Each crop has its own vector of cultivar-specific parameters. There is one instance

--- a/src/agsys/science/AgSysPlaceholder.F90
+++ b/src/agsys/science/AgSysPlaceholder.F90
@@ -3,7 +3,7 @@ module AgSysPlaceholder
   ! TODO(wjs, 2019-11-08) Remove this module!
 
   use AgSysKinds , only : r8
-  use AgSysParams, only : agsys_crop_params_type, agsys_cultivar_params_type
+  use AgSysParams, only : agsys_cultivar_params_type
   use AgSysPhases, only : agsys_phases_type
 
   implicit none
@@ -14,14 +14,13 @@ module AgSysPlaceholder
 
 contains
 
-  subroutine DoTimeStep_Phenology_Placeholder(croptype, phases, crop_params, cultivar_params, &
+  subroutine DoTimeStep_Phenology_Placeholder(croptype, phases, cultivar_params, &
        photoperiod, tair_max, tair_min, tc, sw_avail_ratio, pesw_seedlayer, &
        days_after_sowing, current_stage, days_in_phase, tt_in_phase, &
        days_after_phase, tt_after_phase, cumvd)
     ! Inputs, time-constant
     integer, intent(in) :: croptype
     type(agsys_phases_type) :: phases
-    type(agsys_crop_params_type), intent(in) :: crop_params
     type(agsys_cultivar_params_type), intent(in) :: cultivar_params
 
     ! Inputs, time-varying


### PR DESCRIPTION
Two reasons for this:

(1) The science code doesn't need to know whether a parameter is
    crop-specific or cultivar-specific

(2) This lets any parameter potentially be cultivar-specific, if the
    user wants it